### PR TITLE
fix: Chat header moves out of screen on chatbox focus (#31)

### DIFF
--- a/client/src/components/chat/ChatWindowPanel.jsx
+++ b/client/src/components/chat/ChatWindowPanel.jsx
@@ -240,6 +240,7 @@ export default function ChatWindowPanel({
   const insecureTooltipRef = useRef(null);
   const [insecureTooltipHeight, setInsecureTooltipHeight] = useState(0);
   const permissionBannerRef = useRef(null);
+  const sectionRef = useRef(null);
   const [permissionBannerHeight, setPermissionBannerHeight] = useState(0);
   useEffect(() => {
     if (typeof document === "undefined") return undefined;
@@ -756,6 +757,24 @@ export default function ChatWindowPanel({
     return () => media.removeListener(update);
   }, []);
 
+  useEffect(() => {
+    if (isDesktop) return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const update = () => {
+      const el = sectionRef.current;
+      if (!el) return;
+      el.style.height = `${vv.height}px`;
+      el.style.top = `${vv.offsetTop}px`;
+    };
+    //vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+    };
+  }, [isDesktop]);
+
   function getMessageDayLabel(msg) {
     if (msg?._dayLabel) return msg._dayLabel;
     if (msg?._dayKey) return msg._dayKey;
@@ -983,6 +1002,7 @@ export default function ChatWindowPanel({
 
   return (
     <section
+      ref={sectionRef}
       className={
         "fixed inset-0 top-0 md:relative md:inset-auto md:top-auto flex h-full flex-1 flex-col overflow-hidden border-x border-slate-300/80 bg-white shadow-xl shadow-emerald-500/10 dark:border-white/5 dark:bg-slate-900 md:border md:w-[65%] md:shadow-2xl md:shadow-emerald-500/15 transition-transform duration-300 ease-out will-change-transform " +
         (mobileTab === "chat"


### PR DESCRIPTION
## Summary

Briefly describe what this PR introduces or changes.

This PR is in response to issue #31. This fix should resolve the chat header pushing out of the screen when keyboard appears for typing specifically in iOS browsers Safari, Chrome, Edge.


---

## Type of Change

- [ ] feat (New feature)
- [x] fix (Bug fix)
- [ ] refactor (Code restructuring, no behavior change)
- [ ] chore (Maintenance / tooling / dependencies)
- [ ] ci (Workflow / pipeline changes)
- [ ] docs (Documentation update)

---

## What's Included

Keep this list aligned with the user-facing entries you added to `CHANGELOG.md`.

- UI Bug Fix in iOS (#31)

---

## Why This Change Is Needed

Explain the motivation behind this update.
What problem does it solve or improve?
Described in Summary. See more in #31.

---

## Testing

Describe how this was tested:

- [X] Tested locally
- [X] No breaking changes
- [X] Verified existing functionality still works

---

## Breaking Changes

If this introduces breaking changes, describe them here.
None

If none, write: 
`None`

---

## Screenshots (if applicable)

Add screenshots or recordings if UI-related.
<img width="300" alt="Simulator Screenshot - iPhone 16e - 2026-04-26 at 22 34 03" src="https://github.com/user-attachments/assets/fceb3f70-533a-4ad5-9885-53decaa45877" />

---

## Checklist

- [x] Code follows project structure
- [x] Commit messages follow conventions
- [x] No unnecessary console logs
- [x] Updated `CHANGELOG.md` when user-facing behavior changed
- [x] Ready for merge
