### PR TITLE
fix(UI): hide floating label date when chat scroll top is zero

### DIFF
--- a/client/src/components/chat/ChatWindowPanel.jsx
+++ b/client/src/components/chat/ChatWindowPanel.jsx
@@ -1618,7 +1618,7 @@ export default function ChatWindowPanel({
                   floatingDay,
                 });
               }}
-              className="inline-flex items-center justify-center rounded-full border border-emerald-200/60 bg-white/90 px-3 py-1 text-[11px] font-semibold text-emerald-700 shadow-sm transition hover:border-emerald-300 hover:shadow-md dark:border-emerald-500/30 dark:bg-slate-950 dark:text-emerald-200"
+              className="floating-day-button inline-flex items-center justify-center rounded-full border border-emerald-200/60 bg-white/90 px-3 py-1 text-[11px] font-semibold text-emerald-700 shadow-sm transition hover:border-emerald-300 hover:shadow-md dark:border-emerald-500/30 dark:bg-slate-950 dark:text-emerald-200"
             >
               <span className="leading-none">{floatingDay.label}</span>
             </button>

--- a/client/src/hooks/chat/useChatScroll.js
+++ b/client/src/hooks/chat/useChatScroll.js
@@ -110,6 +110,12 @@ export function useChatScroll({
 
   const handleChatScroll = useCallback(
     (event) => {
+      const floatingDayButton = document.querySelector('.floating-day-button');
+
+      if (floatingDayButton) {
+        floatingDayButton.style.visibility = (event?.target?.scrollTop < 53 ? 'hidden' : 'visible');
+      }
+
       const target = event.currentTarget;
       const previousTop = Number(lastScrollTopRef.current || 0);
       const currentTop = Number(target.scrollTop || 0);


### PR DESCRIPTION
relate to https://github.com/bllackbull/Songbird/issues/38
I initially tried handling this with useState in the ChatWindowPanel.jsx and MessageTimeline.jsx components. However, that approach caused redundant re-renders and sometimes delayed the visibility updates. Because of that, I think direct DOM manipulation is the best temporary solution for now.

That said, I believe the MessageTimeline component should be refactored in the future since it has a few other UI/UX issues. For example, the floating day label could likely be implemented more cleanly using Tailwind utilities such as sticky top-0, among other improvements.

For now, though, I think the approach in this PR resolves the immediate problem.