### PR TITLE
chore: add message reactions migration

### DIFF
--- a/server/migrations/026-message-reactions.js
+++ b/server/migrations/026-message-reactions.js
@@ -1,0 +1,20 @@
+export const migration026MessageReactions = {
+  version: 26,
+  up: ({ db }) => {
+    db.run(`
+      CREATE TABLE IF NOT EXISTS message_reactions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        message_id INTEGER NOT NULL,
+        user_id INTEGER NOT NULL,
+        reaction TEXT NOT NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(message_id, user_id, reaction)
+      )
+    `);
+
+    db.run(`
+      CREATE INDEX IF NOT EXISTS idx_reactions_message
+      ON message_reactions(message_id)
+    `);
+  },
+};

--- a/server/migrations/index.js
+++ b/server/migrations/index.js
@@ -23,6 +23,7 @@ import { migration022MessageClientRequestId } from "./022-message-client-request
 import { migration023ChatLeftMembers } from "./023-chat-left-members.js";
 import { migration024RemoteChannelQueue } from "./024-remote-channel-queue.js";
 import { migration025RemoteChannelPerformance } from "./025-remote-channel-performance.js";
+import { migration026MessageReactions } from "./026-message-reactions.js";
 
 export const migrations = [
   migration001InitialSchema,
@@ -50,4 +51,5 @@ export const migrations = [
   migration023ChatLeftMembers,
   migration024RemoteChannelQueue,
   migration025RemoteChannelPerformance,
+  migration026MessageReactions,
 ];


### PR DESCRIPTION
## Summary
Ports the admin voice reactions database migration into the clean branch and registers it in the migration index so schema version 26 is applied on startup.

## Type of Change
- [x] feat (New feature)
- [ ] fix (Bug fix)
- [ ] refactor (Code restructuring, no behavior change)
- [ ] chore (Maintenance / tooling / dependencies)
- [ ] ci (Workflow / pipeline changes)
- [ ] docs (Documentation update)

## What's Included
- Add `server/migrations/026-message-reactions.js`
- Register `migration026MessageReactions` in `server/migrations/index.js`
- Keep the scope limited to the database layer required for the next server-side reaction work

## Why This Change Is Needed
The reaction flow depends on a dedicated `message_reactions` table and index. Without registering the migration, the new schema would never be applied and the follow-up reaction logic would fail against existing installs.

## Testing
- [ ] Tests were executed
- [ ] Manual verification completed
- Verified by review that the migration file is present and registered in the ordered migration list

## Breaking Changes
None

## Risk
Low

## Rollback Notes
Revert this PR if the migration causes upgrade issues or conflicts with existing database state.