### PR TITLE
feat(domain): add membership lifecycle service

### DIFF
--- a/server/api/chats.js
+++ b/server/api/chats.js
@@ -1,4 +1,5 @@
 import { createInviteToken } from "../lib/inviteTokens.js";
+import { createMembershipService } from "../lib/services/membershipService.js";
 import { normalizeSongbirdSource, normalizeTelegramSource, resolveSongbirdSource } from "../lib/remoteChannels.js";
 
 function registerChatRoutes(app, deps) {
@@ -24,6 +25,7 @@ function registerChatRoutes(app, deps) {
     findChatByInviteToken,
     findDmChat,
     findUserByUsername,
+    findUserById,
     hideChatsForUser,
     hydrateMissingVideoMetadata,
     isGroupMemberRemoved,
@@ -61,6 +63,19 @@ function registerChatRoutes(app, deps) {
     remoteChannelManager,
     upsertRemoteChannelSource,
   } = deps;
+
+  const membershipService = createMembershipService({
+    getChatById: (id) => getChatById(id) || getGroupChat(id) || getChannelChat(id),
+    listChatMembers,
+    addChatMember,
+    removeChatMember,
+    updateChatMemberRole: setChatMemberRole,
+    findUserById,
+    findUserByUsername,
+    findGroupByInviteToken: (tok) => findChatByInviteTarget(tok),
+    addSystemMessage: (chatId, body) =>
+      createMessage(chatId, null, body, null, null, null, { allowPlaintextSystemMessage: true }),
+  });
 
   const resolveClientBaseOrigin = (req) => {
     const referer = String(req.headers?.referer || "").trim();
@@ -706,29 +721,12 @@ function registerChatRoutes(app, deps) {
     }
     const wasMember = isMember(chatId, user.id);
     if (!wasMember) {
-      clearChatMemberLeft(chatId, user.id);
-      addChatMember(chatId, user.id, "member");
-      if (chat.type === "group") {
-        createMessage(
-          chatId,
-          user.id,
-          `[[system:joined:${user.nickname || user.username}]]`,
-          null,
-          null,
-          null,
-          { allowPlaintextSystemMessage: true },
-        );
+      const result = membershipService.joinByInvite({ inviteToken: target, userId: user.id });
+      result.sseEvents.forEach((ev) => {
         try {
-          emitChatEvent(chatId, {
-            type: "chat_message",
-            chatId,
-            username: user.username,
-            body: `[[system:joined:${user.nickname || user.username}]]`,
-          });
-        } catch {
-          // Joining should not fail due to transient event broadcast issues.
-        }
-      }
+          emitSseEvent(ev.targetUsername, ev.payload);
+        } catch (_) {}
+      });
     }
     unhideChat(user.id, chatId);
     emitChatListChangedToChatParticipants(chatId);

--- a/server/lib/services/membershipService.js
+++ b/server/lib/services/membershipService.js
@@ -1,0 +1,271 @@
+/**
+ * Membership Domain Service
+ *
+ * Encapsulates group/channel membership mutations (joining, adding, leaving,
+ * removing, role changes, ownership transfers) and generates standardized
+ * post-commit effects (system messages, SSE payloads, and notification targets).
+ */
+
+export function createMembershipService(dbApi) {
+  const {
+    getChatById,
+    listChatMembers,
+    addChatMember,
+    removeChatMember,
+    updateChatMemberRole,
+    findUserById,
+    findUserByUsername,
+    findGroupByInviteToken,
+    addSystemMessage,
+    getRow,
+    getAll,
+    run,
+  } = dbApi;
+
+  /**
+   * Helper to check if a user previously left a chat.
+   */
+  function isUserPriorLeft(chatId, userId) {
+    if (typeof getRow === "function") {
+      const priorLeft = getRow(
+        `SELECT 1 AS prior_left
+         FROM chat_left_members
+         WHERE chat_id = ? AND user_id = ?
+         UNION
+         SELECT 1 AS prior_left
+         FROM chat_messages
+         WHERE chat_id = ? AND user_id = ? AND body LIKE ?
+         LIMIT 1`,
+        [
+          Number(chatId),
+          Number(userId),
+          Number(chatId),
+          Number(userId),
+          "[[system:left:%",
+        ],
+      );
+      return Boolean(priorLeft?.prior_left);
+    }
+    return false;
+  }
+
+  /**
+   * Helper to clean up prior left markers on rejoin.
+   */
+  function clearPriorLeft(chatId, userId) {
+    if (typeof run === "function") {
+      run("DELETE FROM chat_left_members WHERE chat_id = ? AND user_id = ?", [
+        Number(chatId),
+        Number(userId),
+      ]);
+    }
+  }
+
+  /**
+   * Helper to collect system messages & SSE payloads for members.
+   */
+  function buildEffects(chatId, systemMsgBody, updatedMemberUsernames = []) {
+    const chat = getChatById(Number(chatId));
+    const members = listChatMembers(Number(chatId)) || [];
+    const memberUsernames = members.map((m) =>
+      String(m.username || "").toLowerCase(),
+    );
+
+    const sseEvents = [];
+    const pushRecipients = [];
+
+    // Notify all members (plus specific targets who may have left) of chat updates
+    const sseTargets = new Set([
+      ...memberUsernames,
+      ...updatedMemberUsernames.map((u) => String(u).toLowerCase()),
+    ]);
+    sseTargets.forEach((username) => {
+      if (username) {
+        sseEvents.push({
+          targetUsername: username,
+          payload: { type: "chat_updated", chatId: Number(chatId) },
+        });
+        sseEvents.push({
+          targetUsername: username,
+          payload: { type: "chat_list_changed", chatId: Number(chatId) },
+        });
+      }
+    });
+
+    let systemMessageResult = null;
+    if (
+      systemMsgBody &&
+      chat &&
+      chat.type === "group" &&
+      typeof addSystemMessage === "function"
+    ) {
+      systemMessageResult = addSystemMessage(Number(chatId), systemMsgBody);
+    }
+
+    return {
+      chat,
+      members,
+      systemMessage: systemMessageResult,
+      sseEvents,
+      pushRecipients: members.map((m) => Number(m.id)),
+    };
+  }
+
+  /**
+   * Add users to a chat (or rejoin).
+   */
+  function addMembers({
+    chatId,
+    targetUserIds = [],
+    role = "member",
+    force = false,
+  }) {
+    const chat = getChatById(Number(chatId));
+    if (!chat) throw new Error("Chat not found");
+
+    let addedCount = 0;
+    let skippedCount = 0;
+    const addedUsernames = [];
+
+    const existingMembers = listChatMembers(Number(chatId)) || [];
+    const existingUserIds = new Set(existingMembers.map((m) => Number(m.id)));
+
+    for (const userId of targetUserIds) {
+      const numUserId = Number(userId);
+      if (existingUserIds.has(numUserId)) {
+        skippedCount++;
+        continue;
+      }
+
+      if (!force && isUserPriorLeft(chatId, numUserId)) {
+        skippedCount++;
+        continue;
+      }
+
+      clearPriorLeft(chatId, numUserId);
+      addChatMember(Number(chatId), numUserId, role);
+      addedCount++;
+
+      const user = findUserById(numUserId);
+      if (user?.username) {
+        addedUsernames.push(user.username);
+      }
+    }
+
+    const effects = buildEffects(
+      chatId,
+      addedUsernames.length === 1
+        ? `[[system:joined:${addedUsernames[0]}]]`
+        : null,
+      addedUsernames,
+    );
+
+    return {
+      success: true,
+      addedCount,
+      skippedCount,
+      ...effects,
+    };
+  }
+
+  /**
+   * Join group via invite token.
+   */
+  function joinByInvite({ inviteToken, userId }) {
+    const chat = findGroupByInviteToken(inviteToken);
+    if (!chat) throw new Error("Invalid invite token");
+
+    const user = findUserById(Number(userId));
+    if (!user) throw new Error("User not found");
+
+    clearPriorLeft(chat.id, user.id);
+    addChatMember(Number(chat.id), Number(user.id), "member");
+
+    const nickname = user.nickname || user.username;
+    const effects = buildEffects(chat.id, `[[system:joined:${nickname}]]`, [
+      user.username,
+    ]);
+
+    return {
+      success: true,
+      chat,
+      ...effects,
+    };
+  }
+
+  /**
+   * Leave a chat.
+   */
+  function leaveChat({ chatId, userId }) {
+    const chat = getChatById(Number(chatId));
+    if (!chat) throw new Error("Chat not found");
+
+    const user = findUserById(Number(userId));
+    if (!user) throw new Error("User not found");
+
+    removeChatMember(Number(chatId), Number(userId));
+
+    const nickname = user.nickname || user.username;
+    const effects = buildEffects(chatId, `[[system:left:${nickname}]]`, [
+      user.username,
+    ]);
+
+    return {
+      success: true,
+      chat,
+      ...effects,
+    };
+  }
+
+  /**
+   * Remove a member from a chat.
+   */
+  function removeMember({ chatId, targetUserId, removedByUserId }) {
+    const chat = getChatById(Number(chatId));
+    if (!chat) throw new Error("Chat not found");
+
+    const targetUser = findUserById(Number(targetUserId));
+    if (!targetUser) throw new Error("User not found");
+
+    removeChatMember(Number(chatId), Number(targetUserId));
+
+    const nickname = targetUser.nickname || targetUser.username;
+    const effects = buildEffects(chatId, `[[system:removed:${nickname}]]`, [
+      targetUser.username,
+    ]);
+
+    return {
+      success: true,
+      chat,
+      ...effects,
+    };
+  }
+
+  /**
+   * Update member role.
+   */
+  function updateMemberRole({ chatId, targetUserId, newRole }) {
+    const chat = getChatById(Number(chatId));
+    if (!chat) throw new Error("Chat not found");
+
+    const targetUser = findUserById(Number(targetUserId));
+    if (!targetUser) throw new Error("User not found");
+
+    updateChatMemberRole(Number(chatId), Number(targetUserId), newRole);
+    const effects = buildEffects(chatId, null, [targetUser.username]);
+
+    return {
+      success: true,
+      chat,
+      ...effects,
+    };
+  }
+
+  return {
+    addMembers,
+    joinByInvite,
+    leaveChat,
+    removeMember,
+    updateMemberRole,
+  };
+}

--- a/server/test/lib/services/membershipService.test.js
+++ b/server/test/lib/services/membershipService.test.js
@@ -1,0 +1,135 @@
+import { describe, test, expect, vi } from "vitest";
+import { createMembershipService } from "../../../lib/services/membershipService.js";
+
+describe("membershipService", () => {
+  const createMockDb = (overrides = {}) => {
+    const membersMap = new Map();
+    const chatsMap = new Map();
+    const usersMap = new Map();
+
+    // Default seed
+    chatsMap.set(1, {
+      id: 1,
+      type: "group",
+      name: "Test Group",
+      invite_token: "tok123",
+    });
+    usersMap.set(10, { id: 10, username: "alice", nickname: "Alice" });
+    usersMap.set(20, { id: 20, username: "bob", nickname: "Bob" });
+
+    membersMap.set(1, [{ id: 10, username: "alice", role: "owner" }]);
+
+    return {
+      getChatById: vi.fn((id) => chatsMap.get(Number(id)) || null),
+      listChatMembers: vi.fn((id) => membersMap.get(Number(id)) || []),
+      addChatMember: vi.fn((chatId, userId, role) => {
+        const list = membersMap.get(Number(chatId)) || [];
+        const u = usersMap.get(Number(userId));
+        if (u) {
+          list.push({ id: u.id, username: u.username, role });
+          membersMap.set(Number(chatId), list);
+        }
+      }),
+      removeChatMember: vi.fn((chatId, userId) => {
+        const list = membersMap.get(Number(chatId)) || [];
+        membersMap.set(
+          Number(chatId),
+          list.filter((m) => Number(m.id) !== Number(userId)),
+        );
+      }),
+      updateChatMemberRole: vi.fn((chatId, userId, role) => {
+        const list = membersMap.get(Number(chatId)) || [];
+        const item = list.find((m) => Number(m.id) === Number(userId));
+        if (item) item.role = role;
+      }),
+      findUserById: vi.fn((id) => usersMap.get(Number(id)) || null),
+      findUserByUsername: vi.fn(
+        (un) => [...usersMap.values()].find((u) => u.username === un) || null,
+      ),
+      findGroupByInviteToken: vi.fn(
+        (tok) =>
+          [...chatsMap.values()].find((c) => c.invite_token === tok) || null,
+      ),
+      addSystemMessage: vi.fn((chatId, body) => ({
+        id: 99,
+        chat_id: chatId,
+        body,
+      })),
+      getRow: vi.fn(),
+      run: vi.fn(),
+      ...overrides,
+    };
+  };
+
+  test("addMembers adds user and generates system message and sse payloads", () => {
+    const db = createMockDb();
+    const service = createMembershipService(db);
+
+    const res = service.addMembers({ chatId: 1, targetUserIds: [20] });
+    expect(res.success).toBe(true);
+    expect(res.addedCount).toBe(1);
+    expect(db.addChatMember).toHaveBeenCalledWith(1, 20, "member");
+    expect(db.addSystemMessage).toHaveBeenCalledWith(
+      1,
+      "[[system:joined:bob]]",
+    );
+    expect(res.sseEvents.length).toBeGreaterThan(0);
+  });
+
+  test("joinByInvite resolves chat by token and adds member", () => {
+    const db = createMockDb();
+    const service = createMembershipService(db);
+
+    const res = service.joinByInvite({ inviteToken: "tok123", userId: 20 });
+    expect(res.success).toBe(true);
+    expect(res.chat.id).toBe(1);
+    expect(db.addChatMember).toHaveBeenCalledWith(1, 20, "member");
+    expect(db.addSystemMessage).toHaveBeenCalledWith(
+      1,
+      "[[system:joined:Bob]]",
+    );
+  });
+
+  test("leaveChat removes user and emits left system message", () => {
+    const db = createMockDb();
+    const service = createMembershipService(db);
+
+    const res = service.leaveChat({ chatId: 1, userId: 10 });
+    expect(res.success).toBe(true);
+    expect(db.removeChatMember).toHaveBeenCalledWith(1, 10);
+    expect(db.addSystemMessage).toHaveBeenCalledWith(
+      1,
+      "[[system:left:Alice]]",
+    );
+  });
+
+  test("removeMember removes target user and emits removed system message", () => {
+    const db = createMockDb();
+    const service = createMembershipService(db);
+
+    const res = service.removeMember({
+      chatId: 1,
+      targetUserId: 10,
+      removedByUserId: 20,
+    });
+    expect(res.success).toBe(true);
+    expect(db.removeChatMember).toHaveBeenCalledWith(1, 10);
+    expect(db.addSystemMessage).toHaveBeenCalledWith(
+      1,
+      "[[system:removed:Alice]]",
+    );
+  });
+
+  test("updateMemberRole updates role in db and emits sse event", () => {
+    const db = createMockDb();
+    const service = createMembershipService(db);
+
+    const res = service.updateMemberRole({
+      chatId: 1,
+      targetUserId: 10,
+      newRole: "admin",
+    });
+    expect(res.success).toBe(true);
+    expect(db.updateChatMemberRole).toHaveBeenCalledWith(1, 10, "admin");
+  });
+});


### PR DESCRIPTION
- Create domain membership service to handle user joins, leaves, removals, and role updates
- Standardize system message generation and SSE effect payloads
- Refactor group invite join route in server/api/chats.js
- Add unit tests for membership service